### PR TITLE
PLATY-550 Keeping name of uploaded file as a metadata field

### DIFF
--- a/app/connectors/s3/S3UploadFormGenerator.scala
+++ b/app/connectors/s3/S3UploadFormGenerator.scala
@@ -61,13 +61,14 @@ class S3UploadFormGenerator(
     policySignature: String) = {
 
     val fields = Map(
-      "x-amz-algorithm"  -> "AWS4-HMAC-SHA256",
-      "x-amz-credential" -> signingCredentials,
-      "x-amz-date"       -> timeStamp,
-      "policy"           -> encodedPolicy,
-      "x-amz-signature"  -> policySignature,
-      "acl"              -> uploadParameters.acl,
-      "key"              -> uploadParameters.objectKey
+      "x-amz-algorithm"              -> "AWS4-HMAC-SHA256",
+      "x-amz-credential"             -> signingCredentials,
+      "x-amz-date"                   -> timeStamp,
+      "policy"                       -> encodedPolicy,
+      "x-amz-signature"              -> policySignature,
+      "acl"                          -> uploadParameters.acl,
+      "key"                          -> uploadParameters.objectKey,
+      "x-amz-meta-original-filename" -> "${filename}"
     )
 
     val sessionCredentials = securityToken.map(t => Map("x-amz-security-token" -> t)).getOrElse(Map.empty)
@@ -93,7 +94,7 @@ class S3UploadFormGenerator(
 
     val metadataJson = uploadParameters.additionalMetadata.map {
       case (k, v) => Json.obj(s"x-amz-meta-$k" -> v)
-    }
+    }.toSeq :+ Json.arr("starts-with", "$x-amz-meta-original-filename", "")
 
     val contentTypeConstraintJson =
       uploadParameters.expectedContentType.map(contentType => Json.obj("Content-Type" -> contentType))

--- a/app/domain/PrepareUploadService.scala
+++ b/app/domain/PrepareUploadService.scala
@@ -19,11 +19,14 @@ class PrepareUploadService @Inject()(
     val expiration = Instant.now().plus(configuration.fileExpirationPeriod)
 
     val result =
-      PreparedUpload(reference = reference, uploadRequest = generatePost(reference.value, expiration, settings, consumingService))
+      PreparedUpload(
+        reference     = reference,
+        uploadRequest = generatePost(reference.value, expiration, settings, consumingService))
 
     try {
       MDC.put("file-reference", reference.value)
-      Logger.info(s"Generated file-reference: [${reference.value}], for settings: [$settings], with expiration at: [$expiration].")
+      Logger.info(
+        s"Generated file-reference: [${reference.value}], for settings: [$settings], with expiration at: [$expiration].")
 
       metrics.defaultRegistry.counter("uploadInitiated").inc()
 
@@ -35,7 +38,11 @@ class PrepareUploadService @Inject()(
 
   private def generateReference() = Reference(UUID.randomUUID().toString)
 
-  private def generatePost(key: String, expiration: Instant, settings: UploadSettings, consumingService: String): UploadFormTemplate = {
+  private def generatePost(
+    key: String,
+    expiration: Instant,
+    settings: UploadSettings,
+    consumingService: String): UploadFormTemplate = {
 
     val minFileSize = settings.minimumFileSize.getOrElse(0)
     val maxFileSize = settings.maximumFileSize.getOrElse(globalFileSizeLimit)
@@ -45,11 +52,11 @@ class PrepareUploadService @Inject()(
     require(minFileSize <= maxFileSize, "Minimum file size is greater than maximum file size")
 
     val uploadParameters = UploadParameters(
-      expirationDateTime  = expiration,
-      bucketName          = configuration.inboundBucketName,
-      objectKey           = key,
-      acl                 = "private",
-      additionalMetadata  = Map(
+      expirationDateTime = expiration,
+      bucketName         = configuration.inboundBucketName,
+      objectKey          = key,
+      acl                = "private",
+      additionalMetadata = Map(
         "callback-url"      -> settings.callbackUrl,
         "consuming-service" -> consumingService
       ),


### PR DESCRIPTION
In order to help apache-tika perform better when detecting mime type.