### PR TITLE
PLATY-548: Revert allowedUserAgents configuration format to a single …

### DIFF
--- a/app/config/ServiceConfiguration.scala
+++ b/app/config/ServiceConfiguration.scala
@@ -39,8 +39,10 @@ class PlayBasedServiceConfiguration @Inject()(configuration: Configuration) exte
   override def globalFileSizeLimit = getRequired(configuration.getInt, "global.file.size.limit")
 
   override def allowedUserAgents: Seq[String] =
-    configuration.getStringSeq("userAgentFilter.allowedUserAgents").map {_
-        .filter(isNotBlank)
+    configuration.getString("userAgentFilter.allowedUserAgents").map {_
+      .split(",")
+      .toSeq
+      .filter(isNotBlank)
     }.getOrElse(Nil)
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -111,7 +111,7 @@ aws {
 
 global.file.size.limit = 104857600
 
-userAgentFilter.allowedUserAgents = []
+userAgentFilter.allowedUserAgents = ""
 
   # Microservice specific config
 

--- a/it/controllers/PrepareUploadControllerISpec.scala
+++ b/it/controllers/PrepareUploadControllerISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class PrepareUploadControllerISpec extends UnitSpec with GuiceOneAppPerSuite with GivenWhenThen {
   override implicit lazy val app: Application = new GuiceApplicationBuilder().configure(
-    "userAgentFilter.allowedUserAgents" -> Seq("PrepareUploadControllerISpec")
+    "userAgentFilter.allowedUserAgents" -> "PrepareUploadControllerISpec"
   ).build()
 
   "PrepareUploadController" should {


### PR DESCRIPTION
…string, parsed by the application.