### PR TITLE
BDOG-3562: let bootstrap manage jackson-core dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ lazy val microservice = Project("upscan-initiate", file("."))
   .settings(scalacOptions += "-Wconf:src=routes/.*:s")
   .settings(playDefaultPort := 9571)
   .settings(libraryDependencies ++= AppDependencies())
-  .settings(resolvers += Resolver.jcenterRepo)
   .settings(Test / parallelExecution := false)
 
 lazy val it = project

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,12 +1,13 @@
 import sbt._
 
 object AppDependencies {
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "10.1.0"
+  private val awsSdkVersion = "2.35.1"
 
   private val compile = Seq(
     "uk.gov.hmrc"            %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "software.amazon.awssdk" %  "s3"                        % "2.30.30",
-    "software.amazon.awssdk" %  "secretsmanager"            % "2.30.30"
+    "software.amazon.awssdk" %  "s3"                        % awsSdkVersion,
+    "software.amazon.awssdk" %  "secretsmanager"            % awsSdkVersion
   )
 
   private val test = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework" %  "sbt-plugin"            % "3.0.8")
 addSbtPlugin("uk.gov.hmrc"       %  "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       %  "sbt-distributables"    % "2.6.0")
 addSbtPlugin("org.scoverage"     %  "sbt-scoverage"         % "2.0.11")


### PR DESCRIPTION
- Bootstrap 10.1.0 provides jackson-core 2.15.3 which is sufficient